### PR TITLE
Test cases #1 - Make headless an option

### DIFF
--- a/bin/test_locally.sh
+++ b/bin/test_locally.sh
@@ -1,7 +1,7 @@
 echo "test_locally"
 echo "Running pytest to locally Test All Test Cases (Functional Testing)"
 
-pytest testcases
+pytest $@ testcases
 
 if [[ "$?" == "0" ]]; then
     echo "PASS"

--- a/testcases/conftest.py
+++ b/testcases/conftest.py
@@ -1,17 +1,22 @@
 import pytest
 
 
+def pytest_addoption(parser):
+    group = parser.getgroup('selenium', 'selenium')
+    group._addoption('--headless',
+                     action='store_true',
+                     help='enable headless mode for supported browsers.')
+
+
 @pytest.fixture
 def chrome_options(chrome_options, pytestconfig):
-    capabilities = dict(pytestconfig.option.capabilities)
-    if 'true' == capabilities.get('headless', 'false').lower():
+    if pytestconfig.getoption('headless'):
         chrome_options.add_argument('headless')
     return chrome_options
 
 
 @pytest.fixture
 def firefox_options(firefox_options, pytestconfig):
-    capabilities = dict(pytestconfig.option.capabilities)
-    if 'true' == capabilities.get('headless', 'false').lower():
+    if pytestconfig.getoption('headless'):
         firefox_options.set_headless(True)
     return firefox_options


### PR DESCRIPTION
Test cases #1 - Make headless an option

This PR adds a config python file for pytest that makes `--headless` a pytest command  line option for both Chrome and Firefox.